### PR TITLE
file mismatch handler

### DIFF
--- a/lib/chef/knife/swap_base.rb
+++ b/lib/chef/knife/swap_base.rb
@@ -56,7 +56,11 @@ class Chef
         current_configs.each do |cfg|
           configs << File.basename(cfg, '.rb').split('-')[1..-1].join('-')
         end
-        puts "#{Chef::Knife.ui.color('current[', :cyan)}#{configs.join(',')}#{Chef::Knife.ui.color(']', :cyan)}"
+        if configs.empty? && File.exist?(knife_config)
+          puts Chef::Knife.ui.color("Available configs do not match current knife.rb.\nDid you modify knife.rb or matching knife-<config>.rb?", :red)
+        else
+          puts "#{Chef::Knife.ui.color('current[', :cyan)}#{configs.join(',')}#{Chef::Knife.ui.color(']', :cyan)}"
+        end
       end
 
       # copy config to knife.rb

--- a/lib/knife-swap/version.rb
+++ b/lib/knife-swap/version.rb
@@ -3,6 +3,6 @@ module Knife
   # simple module to provide version
   module Swap
     # knife-swap version
-    VERSION = '0.1.0'.freeze
+    VERSION = '0.1.1'.freeze
   end
 end


### PR DESCRIPTION
Added a warning message to the console if knife.rb no longer matches any available knife-*.rb configurations.
